### PR TITLE
Add `display` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,9 @@ A JupyterLab and Jupyter Notebook extension for rendering data with dynamically 
 To render React output in IPython:
 
 ```python
-from IPython.display import display
+from jupyterlab_react import React
 
-def React(data, module=None):
-    bundle = {
-        'application/vnd.react.v1+json': {
-            'module': module,
-            'type': data['type'],
-            'props': data['props']
-        },
-        'application/json': data['props'],
-        'text/plain': '<IPython.core.display.React.object>'
-    }
-    display(bundle, raw=True)
-    
-React({
+element = {
     'type': 'JSONTree',
     'props': {
         'data': [
@@ -37,7 +25,9 @@ React({
         ],
         'theme': 'google'
     }
-}, module='react-json-tree')
+}
+    
+React(element, module='react-json-tree')
 ```
 
 ## Install

--- a/jupyterlab_react/__init__.py
+++ b/jupyterlab_react/__init__.py
@@ -1,6 +1,8 @@
+from IPython.display import display
+
+
 # Running `npm run build` will create static resources in the static
 # directory of this Python package (and create that directory if necessary).
-
 
 def _jupyter_labextension_paths():
     return [{
@@ -15,3 +17,20 @@ def _jupyter_nbextension_paths():
         'dest': 'jupyterlab_react',
         'require': 'jupyterlab_react/extension'
     }]
+
+
+# A display function that can be used within a notebook. E.g.:
+#   from jupyterlab_react import React
+#   React(data)
+    
+def React(data, module=None):
+    bundle = {
+        'application/vnd.react.v1+json': {
+            'module': module,
+            'type': data['type'],
+            'props': data['props']
+        },
+        'application/json': data,
+        'text/plain': 'jupyterlab_react.React object>'
+    }
+    display(bundle, raw=True)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup_args = dict(
     include_package_data = True,
     install_requires = [
         'jupyterlab>=0.8.0',
+        'ipython>=1.0.0'
     ]
 )
 


### PR DESCRIPTION
Provides a `display` method that can be imported into a notebook:

```py
from jupyterlab_react import React

element = {
    'type': 'JSONTree',
    'props': {
        'data': [
            {'month': 'September', 'profit': 35000, 'loss': 2000},
            {'month': 'October', 'profit': 42000, 'loss': 8000},
            {'month': 'November', 'profit': 55000, 'loss': 5000}
        ],
        'theme': 'google'
    }
}
    
React(element, module='react-json-tree')
```